### PR TITLE
98 feature   add calendar to home page

### DIFF
--- a/PyFitness/database/db.py
+++ b/PyFitness/database/db.py
@@ -111,7 +111,7 @@ def get_calendar_events(userId: int):
                SELECT gs::date::text, pd."ActivityName", 'programme' as type
                FROM "Programme" p
                JOIN "ProgrammeDay" pd ON p."ProgrammeID" = pd."ProgrammeID"
-               CROSS JOIN generate_series(p."StartDate", p."EndDate", '1 day'::interval) gs
+               CROSS JOIN generate_series(LEAST(p."StartDate", p."EndDate"), GREATEST(p."StartDate", p."EndDate"), '1 day'::interval) gs
                WHERE p."UserID" = %s
                AND TO_CHAR(gs, 'Day') ILIKE pd."DayOfWeek" || '%%' ''',
             (userId, userId, userId)

--- a/PyFitness/routers/addworkout.py
+++ b/PyFitness/routers/addworkout.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from database.db import get_connection, get_user_settings
-import datetime
+from datetime import datetime
 
 
 router = APIRouter()
@@ -20,6 +20,8 @@ async def add_workout(request: Request, error: str = None):
     distance_unit = settings[1] if settings else "km"
 
     activityName = request.query_params.get("activityName", "")
+    programmeDayId = request.query_params.get("programmeDayId", "")
+    programmeId = request.query_params.get("programmeId", "")
 
     return f"""
         <html>
@@ -52,6 +54,8 @@ async def add_workout(request: Request, error: str = None):
                         <div class="accent-line"></div>
                         {error_html}
                         <form action="/add-workout" method="post">
+                            <input type="hidden" name="programmeDayId" value="{programmeDayId}">
+                            <input type="hidden" name="programmeId" value="{programmeId}">
                             <div class="form-group">
                                 <label>Workout Name</label>
                                 <input type="text" id="workoutName" name="workoutName" value="{activityName}" placeholder="Enter workout name" required>
@@ -188,7 +192,9 @@ async def add_workout_post(
     request: Request,
     workoutName: str = Form(...),
     workoutDate: str = Form(None),
-    workoutTime: str = Form(None)
+    workoutTime: str = Form(None),
+    programmeDayId: str = Form(None),
+    programmeId: str = Form(None)
 ):
     userId = request.session.get("userId")
 
@@ -198,9 +204,11 @@ async def add_workout_post(
     settings = get_user_settings(userId)
     weight_unit = settings[0] if settings else "kg"
     distance_unit = settings[1] if settings else "km"
-    programmeDayId = request.query_params.get("programmeDayId")
-
+        
     formData = await request.form()
+
+    if not workoutDate:
+        workoutDate = datetime.now().date()
 
     exercises = []
     i = 1
@@ -241,16 +249,6 @@ async def add_workout_post(
     if not workoutName.strip():
         return RedirectResponse(url="/add-workout?error=Workout+name+cannot+be+empty", status_code=303)
 
-    if not workoutDate or workoutDate.strip() == "":
-        workoutDate = datetime.datetime.now().date()
-    else:
-        workoutDate = datetime.datetime.strptime(workoutDate, "%Y-%m-%d").date()
-
-    if not workoutTime or workoutTime.strip() == "":
-        workoutTime = datetime.datetime.now().time()
-    else:
-        workoutTime = datetime.datetime.strptime(workoutTime, "%H:%M").time()
-
     conn = None
     cursor = None
 
@@ -263,6 +261,8 @@ async def add_workout_post(
             (userId, workoutDate, workoutName, workoutTime)
         )
         workoutId = cursor.fetchone()[0]
+
+        print(workoutId, programmeDayId)
 
         if programmeDayId:
             cursor.execute(

--- a/PyFitness/routers/addworkout.py
+++ b/PyFitness/routers/addworkout.py
@@ -40,12 +40,12 @@ async def add_workout(request: Request, error: str = None):
                     <a href="/home" class="navbar-brand">FiTrackr</a>
                     <div class="navbar-links">
                         <a href="/home">Home</a>
-                        <a href="/add-workout" class="active">Add Workout</a>
                         <a href="/programmes">Programmes</a>
                         <a href="/competitions">Competitions</a>
                         <a href="/progress">Progress</a>
                         <a href="/guides">Help</a>
                         <a href="/settings">Settings</a>
+                        <a href="/add-workout" class="add-workout">Add Workout</a>
                         <a href="/logout" class="nav-btn">Logout</a>
                     </div>
                 </nav>
@@ -109,13 +109,13 @@ async def add_workout(request: Request, error: str = None):
                                 <input type="text" name="exerciseName_${{exerciseCount}}" placeholder="e.g. Running"><br><br>
 
                                 <label>Duration (minutes)</label><br>
-                                <input type="number" name="duration_${{exerciseCount}}" placeholder="Enter duration"><br><br>
+                                <input type="number" name="duration_${{exerciseCount}}" min="0" placeholder="Enter duration"><br><br>
 
                                 <label>Distance ({distance_unit})</label><br>
-                                <input type="number" name="distance_${{exerciseCount}}" placeholder="Enter distance" step="0.1"><br><br>
+                                <input type="number" name="distance_${{exerciseCount}}" min="0" placeholder="Enter distance" step="0.1"><br><br>
 
                                 <label>Calories Burned</label><br>
-                                <input type="number" name="calories_${{exerciseCount}}" placeholder="Enter calories"><br><br>
+                                <input type="number" name="calories_${{exerciseCount}}" min="0" placeholder="Enter calories"><br><br>
                             </div>
 
                             <div id="weightFields_${{exerciseCount}}" style="display:none">
@@ -216,10 +216,11 @@ async def add_workout_post(
         exerciseType = formData.get(f"workoutType_{i}")
 
         if exerciseType == "cardio":
+            cardioType = formData.get(f"cardioType_{i}") or ""
             exercises.append({
                 "type": "cardio",
-                "cardioType": formData.get(f"cardioType_{i}"),
-                "name": formData.get(f"exerciseName_{i}"),
+                "cardioType": cardioType,
+                "name": formData.get(f"exerciseName_{i}") or cardioType,
                 "duration": formData.get(f"duration_{i}"),
                 "distance": formData.get(f"distance_{i}"),
                 "calories": formData.get(f"calories_{i}"),
@@ -299,8 +300,8 @@ async def add_workout_post(
                 cursor.execute(
                     '''
                     INSERT INTO "Cardio"
-                    ("ExerciseID", "Duration", "Distance", "TimeUnit", "DistanceUnit", "Calories")
-                    VALUES (%s, %s, %s, %s, %s, %s)
+                    ("ExerciseID", "Duration", "Distance", "TimeUnit", "DistanceUnit", "Calories", "CardioType", "CardioDate")
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
                     ''',
                     (
                         exerciseId,
@@ -308,7 +309,9 @@ async def add_workout_post(
                         exercise["distance"] or 0,
                         "m",
                         distance_unit,
-                        exercise["calories"] or 0
+                        exercise["calories"] or 0,
+                        exercise["cardioType"],
+                        workoutDate
                     )
                 )
             elif exercise["type"] == "weights":

--- a/PyFitness/routers/addworkout.py
+++ b/PyFitness/routers/addworkout.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from database.db import get_connection, get_user_settings
-from datetime import datetime
+import datetime
 
 
 router = APIRouter()
@@ -20,8 +20,6 @@ async def add_workout(request: Request, error: str = None):
     distance_unit = settings[1] if settings else "km"
 
     activityName = request.query_params.get("activityName", "")
-    programmeDayId = request.query_params.get("programmeDayId", "")
-    programmeId = request.query_params.get("programmeId", "")
 
     return f"""
         <html>
@@ -54,8 +52,6 @@ async def add_workout(request: Request, error: str = None):
                         <div class="accent-line"></div>
                         {error_html}
                         <form action="/add-workout" method="post">
-                            <input type="hidden" name="programmeDayId" value="{programmeDayId}">
-                            <input type="hidden" name="programmeId" value="{programmeId}">
                             <div class="form-group">
                                 <label>Workout Name</label>
                                 <input type="text" id="workoutName" name="workoutName" value="{activityName}" placeholder="Enter workout name" required>
@@ -192,9 +188,7 @@ async def add_workout_post(
     request: Request,
     workoutName: str = Form(...),
     workoutDate: str = Form(None),
-    workoutTime: str = Form(None),
-    programmeDayId: str = Form(None),
-    programmeId: str = Form(None)
+    workoutTime: str = Form(None)
 ):
     userId = request.session.get("userId")
 
@@ -204,11 +198,9 @@ async def add_workout_post(
     settings = get_user_settings(userId)
     weight_unit = settings[0] if settings else "kg"
     distance_unit = settings[1] if settings else "km"
-        
-    formData = await request.form()
+    programmeDayId = request.query_params.get("programmeDayId")
 
-    if not workoutDate:
-        workoutDate = datetime.now().date()
+    formData = await request.form()
 
     exercises = []
     i = 1
@@ -249,6 +241,16 @@ async def add_workout_post(
     if not workoutName.strip():
         return RedirectResponse(url="/add-workout?error=Workout+name+cannot+be+empty", status_code=303)
 
+    if not workoutDate or workoutDate.strip() == "":
+        workoutDate = datetime.datetime.now().date()
+    else:
+        workoutDate = datetime.datetime.strptime(workoutDate, "%Y-%m-%d").date()
+
+    if not workoutTime or workoutTime.strip() == "":
+        workoutTime = datetime.datetime.now().time()
+    else:
+        workoutTime = datetime.datetime.strptime(workoutTime, "%H:%M").time()
+
     conn = None
     cursor = None
 
@@ -261,8 +263,6 @@ async def add_workout_post(
             (userId, workoutDate, workoutName, workoutTime)
         )
         workoutId = cursor.fetchone()[0]
-
-        print(workoutId, programmeDayId)
 
         if programmeDayId:
             cursor.execute(

--- a/PyFitness/routers/competitions.py
+++ b/PyFitness/routers/competitions.py
@@ -140,7 +140,7 @@ async def competitions(request: Request, error: str = None):
         try:
             cursor.execute(
                 '''
-                SELECT ROW_NUMBER() OVER (PARTITION BY c."CardioType" ORDER BY c."CardioDate" ASC) as exercise_num, c."CardioType", c."Distance", c."Duration"
+                SELECT c."CardioDate"::text, c."CardioType", c."Distance", c."Duration"
                 FROM "Cardio" c
                 JOIN "Exercise" e ON c."ExerciseID" = e."ExerciseID"
                 JOIN "Workout" w ON e."WorkoutID" = w."WorkoutID"
@@ -151,7 +151,6 @@ async def competitions(request: Request, error: str = None):
             )
             cardio_data = cursor.fetchall()
         except Exception:
-            # CardioType column doesn't exist, skip pace chart
             cardio_data = []
 
         cursor.close()
@@ -177,26 +176,30 @@ async def competitions(request: Request, error: str = None):
         """
         cardio_data = []
 
-    # format cardio data for chart (calculate pace and handle missing/invalid data)
-    cardio_dict = {}
-    for exercise_num, cardio_type, distance, duration in cardio_data:
+    pace_accumulator = {}
+    for cardio_date, cardio_type, distance, duration in cardio_data:
         try:
             distance_float = float(distance) if distance else 0
             duration_float = float(duration) if duration else 0
             if distance_float > 0 and duration_float > 0:
                 pace = duration_float / distance_float
-                if exercise_num not in cardio_dict:
-                    cardio_dict[exercise_num] = {"Run": None, "Cycle": None, "Swim": None}
-                cardio_dict[exercise_num][cardio_type] = round(pace, 2)
+                if cardio_date not in pace_accumulator:
+                    pace_accumulator[cardio_date] = {"Run": [], "Cycle": [], "Swim": []}
+                if cardio_type in pace_accumulator[cardio_date]:
+                    pace_accumulator[cardio_date][cardio_type].append(pace)
         except (ValueError, TypeError):
             continue
 
-    sorted_exercises = sorted(cardio_dict.keys())
+    sorted_dates = sorted(pace_accumulator.keys())
+
+    def avg_pace(values):
+        return round(sum(values) / len(values), 2) if values else None
+
     chart_data = {
-        "exercise_numbers": sorted_exercises,
-        "Run": [cardio_dict[e].get("Run") for e in sorted_exercises],
-        "Cycle": [cardio_dict[e].get("Cycle") for e in sorted_exercises],
-        "Swim": [cardio_dict[e].get("Swim") for e in sorted_exercises]
+        "dates": sorted_dates,
+        "Run": [avg_pace(pace_accumulator[d]["Run"]) for d in sorted_dates],
+        "Cycle": [avg_pace(pace_accumulator[d]["Cycle"]) for d in sorted_dates],
+        "Swim": [avg_pace(pace_accumulator[d]["Swim"]) for d in sorted_dates]
     }
 
     # Show message if no competitions or completed competitions
@@ -285,6 +288,11 @@ async def competitions(request: Request, error: str = None):
 
                         <div class="section-card" style="margin-top: 20px;">
                             <h3>Cardio Pace Trends</h3>
+                            <div style="display:flex; align-items:center; gap:16px; margin-bottom:12px;">
+                                <button type="button" onclick="shiftWindow(-1)">&#8249;</button>
+                                <span id="chartWindowLabel" style="font-family:'Bebas Neue',sans-serif; font-size:1.1rem; letter-spacing:0.05em;"></span>
+                                <button type="button" onclick="shiftWindow(1)">&#8250;</button>
+                            </div>
                             <canvas id="paceChart"></canvas>
                         </div>
                     </div>
@@ -421,20 +429,61 @@ async def competitions(request: Request, error: str = None):
                         }}
                     }}
 
-                    //pace chart
                     const chartData = {chart_data_json};
-                    if (chartData.exercise_numbers && chartData.exercise_numbers.length > 0) {{
+                    const WINDOW_MONTHS = 3;
+                    let windowOffset = 0;
+                    let paceChart = null;
+
+                    function parseLocalDate(str) {{
+                        const [y, m, d] = str.split('-').map(Number);
+                        return new Date(y, m - 1, d);
+                    }}
+
+                    function getWindowBounds(offset) {{
+                        const now = new Date();
+                        const end = new Date(now.getFullYear(), now.getMonth() - offset * WINDOW_MONTHS + 1, 0);
+                        const start = new Date(end.getFullYear(), end.getMonth() - WINDOW_MONTHS + 1, 1);
+                        return {{ start, end }};
+                    }}
+
+                    function filterWindow(offset) {{
+                        const {{ start, end }} = getWindowBounds(offset);
+                        const indices = chartData.dates.reduce((acc, d, i) => {{
+                            const date = parseLocalDate(d);
+                            if (date >= start && date <= end) acc.push(i);
+                            return acc;
+                        }}, []);
+                        return {{
+                            labels: indices.map(i => chartData.dates[i]),
+                            Run: indices.map(i => chartData.Run[i]),
+                            Cycle: indices.map(i => chartData.Cycle[i]),
+                            Swim: indices.map(i => chartData.Swim[i])
+                        }};
+                    }}
+
+                    function updateLabel(offset) {{
+                        const {{ start, end }} = getWindowBounds(offset);
+                        const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+                        document.getElementById('chartWindowLabel').textContent =
+                            months[start.getMonth()] + ' ' + start.getFullYear() + ' – ' +
+                            months[end.getMonth()] + ' ' + end.getFullYear();
+                    }}
+
+                    function renderChart(offset) {{
+                        const filtered = filterWindow(offset);
+                        updateLabel(offset);
+                        if (paceChart) paceChart.destroy();
                         const ctx = document.getElementById('paceChart').getContext('2d');
-                        new Chart(ctx, {{
+                        paceChart = new Chart(ctx, {{
                             type: 'line',
                             data: {{
-                                labels: chartData.exercise_numbers.map(n => 'Exercise ' + n),
+                                labels: filtered.labels,
                                 datasets: [
                                     {{
                                         label: 'Run',
-                                        data: chartData.Run,
+                                        data: filtered.Run,
                                         borderColor: '#FF6B6B',
-                                        backgroundColor: 'rgba(255, 107, 107, 0.1)',
+                                        backgroundColor: 'rgba(255,107,107,0.1)',
                                         borderWidth: 2,
                                         fill: false,
                                         tension: 0.1,
@@ -442,9 +491,9 @@ async def competitions(request: Request, error: str = None):
                                     }},
                                     {{
                                         label: 'Cycle',
-                                        data: chartData.Cycle,
+                                        data: filtered.Cycle,
                                         borderColor: '#4ECDC4',
-                                        backgroundColor: 'rgba(78, 205, 196, 0.1)',
+                                        backgroundColor: 'rgba(78,205,196,0.1)',
                                         borderWidth: 2,
                                         fill: false,
                                         tension: 0.1,
@@ -452,9 +501,9 @@ async def competitions(request: Request, error: str = None):
                                     }},
                                     {{
                                         label: 'Swim',
-                                        data: chartData.Swim,
+                                        data: filtered.Swim,
                                         borderColor: '#45B7D1',
-                                        backgroundColor: 'rgba(69, 183, 209, 0.1)',
+                                        backgroundColor: 'rgba(69,183,209,0.1)',
                                         borderWidth: 2,
                                         fill: false,
                                         tension: 0.1,
@@ -464,28 +513,23 @@ async def competitions(request: Request, error: str = None):
                             }},
                             options: {{
                                 responsive: true,
-                                plugins: {{
-                                    legend: {{
-                                        display: true,
-                                        position: 'top'
-                                    }}
-                                }},
+                                plugins: {{ legend: {{ display: true, position: 'top' }} }},
                                 scales: {{
-                                    y: {{
-                                        title: {{
-                                            display: true,
-                                            text: 'Pace (mins/km)'
-                                        }}
-                                    }},
-                                    x: {{
-                                        title: {{
-                                            display: true,
-                                            text: 'Exercise Number'
-                                        }}
-                                    }}
+                                    y: {{ title: {{ display: true, text: 'Pace (mins/km)' }} }},
+                                    x: {{ title: {{ display: true, text: 'Date' }}, ticks: {{ maxTicksLimit: 8 }} }}
                                 }}
                             }}
                         }});
+                    }}
+
+                    function shiftWindow(direction) {{
+                        windowOffset -= direction;
+                        if (windowOffset < 0) windowOffset = 0;
+                        renderChart(windowOffset);
+                    }}
+
+                    if (chartData.dates && chartData.dates.length > 0) {{
+                        renderChart(windowOffset);
                     }}
                 </script>
             </body>

--- a/PyFitness/routers/home.py
+++ b/PyFitness/routers/home.py
@@ -127,9 +127,11 @@ async def home(request: Request):
 
                         let html = `
                             <h2>${{data.name}}</h2>
+                            ${{data.programme ? `<p><strong>Programme:</strong> ${{data.programme}}</p>` : ''}}
                             <p><strong>Date:</strong> ${{data.date}}</p>
                             <p><strong>Time:</strong> ${{data.time}}</p>
                             <hr>
+
                         `;
 
                         data.exercises.forEach(ex => {{
@@ -332,9 +334,11 @@ async def workout_details(workout_id: int, request: Request):
     cur = conn.cursor()
 
     cur.execute(
-        '''SELECT "Name", "WorkoutDate", "WorkoutTime"
-           FROM "Workout"
-           WHERE "WorkoutID" = %s''',
+        '''SELECT w."Name", w."WorkoutDate", w."WorkoutTime", p."Name"
+        FROM "Workout" w
+        LEFT JOIN "ProgrammeDay" pd ON pd."WorkoutID" = w."WorkoutID"
+        LEFT JOIN "Programme" p ON p."ProgrammeID" = pd."ProgrammeID"
+        WHERE w."WorkoutID" = %s''',
         (workout_id,)
     )
     workout = cur.fetchone()
@@ -351,6 +355,7 @@ async def workout_details(workout_id: int, request: Request):
         "name": workout[0],
         "date": str(workout[1]),
         "time": str(workout[2])[:8],
+        "programme": workout[3],
         "exercises": []
     }
 

--- a/PyFitness/routers/home.py
+++ b/PyFitness/routers/home.py
@@ -127,11 +127,9 @@ async def home(request: Request):
 
                         let html = `
                             <h2>${{data.name}}</h2>
-                            ${{data.programme ? `<p><strong>Programme:</strong> ${{data.programme}}</p>` : ''}}
                             <p><strong>Date:</strong> ${{data.date}}</p>
                             <p><strong>Time:</strong> ${{data.time}}</p>
                             <hr>
-
                         `;
 
                         data.exercises.forEach(ex => {{
@@ -334,11 +332,9 @@ async def workout_details(workout_id: int, request: Request):
     cur = conn.cursor()
 
     cur.execute(
-        '''SELECT w."Name", w."WorkoutDate", w."WorkoutTime", p."Name"
-        FROM "Workout" w
-        LEFT JOIN "ProgrammeDay" pd ON pd."WorkoutID" = w."WorkoutID"
-        LEFT JOIN "Programme" p ON p."ProgrammeID" = pd."ProgrammeID"
-        WHERE w."WorkoutID" = %s''',
+        '''SELECT "Name", "WorkoutDate", "WorkoutTime"
+           FROM "Workout"
+           WHERE "WorkoutID" = %s''',
         (workout_id,)
     )
     workout = cur.fetchone()
@@ -355,7 +351,6 @@ async def workout_details(workout_id: int, request: Request):
         "name": workout[0],
         "date": str(workout[1]),
         "time": str(workout[2])[:8],
-        "programme": workout[3],
         "exercises": []
     }
 

--- a/PyFitness/routers/programme.py
+++ b/PyFitness/routers/programme.py
@@ -2,7 +2,6 @@ from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from database.db import get_connection
 from datetime import datetime
-from urllib.parse import quote
 
 router = APIRouter()
 
@@ -255,6 +254,9 @@ async def add_programme(
         if endDate < startDate:
             return RedirectResponse(url="/programmes?error=End+date+cannot+be+before+start+date", status_code=303)
 
+        if startDate < datetime.now().date():
+            return RedirectResponse(url="/programmes?error=Start+date+cannot+be+before+today", status_code=303)
+
     except ValueError:
         return RedirectResponse(url="/programmes?error=Invalid+date+format", status_code=303)
 
@@ -367,8 +369,9 @@ async def view_programme(request: Request, programmeId: int):
         notes_html = f'<p style="color:var(--text-secondary); font-size:0.85rem">{day[5]}</p>' if day[5] else ""
         workout_html = ''
         action_html = ''
-        
-        if not day[4]:
+        if day[6]:
+            workout_html = f'<a href="/workouts/{day[6]}">View Workout</a>'
+        elif not day[4]:
                action_html = f"""
                     <form action="/programmes/complete" method="post">
                         <input type="hidden" name="programmeDayId" value="{day[0]}">
@@ -395,7 +398,7 @@ async def view_programme(request: Request, programmeId: int):
                 <form action="/programmes/complete" method="post">
                     <input type="hidden" name="programmeDayId" value="{day[0]}">
                     <input type="hidden" name="programmeId" value="{programmeId}">
-                    <button type="submit" name="action" value="undo" class="secondary">
+                    <button type="submit" name="action" value="quick" class="secondary">
                         Undo
                     </button>
                 </form>
@@ -488,41 +491,38 @@ async def complete_day(
     if "userId" not in request.session:
         return RedirectResponse(url="/login?error=Please+log+in", status_code=303)
 
-    action = (action or "").strip().lower()
-
     try:
         conn = get_connection()
         cursor = conn.cursor()
 
-        if action == "undo":
+        if action == "quick":
             cursor.execute(
-                'UPDATE "ProgrammeDay" SET "Completed" = FALSE, "Notes" = NULL, "WorkoutID" = NULL WHERE "ProgrammeDayID" = %s',
-                (programmeDayId,)
+                'UPDATE "ProgrammeDay" SET "Completed" = NOT "Completed", "Notes" = %s WHERE "ProgrammeDayID" = %s',
+                (notes or None, programmeDayId)
             )
-        else:
+            
+
+            conn.commit()
+            cursor.close()
+            conn.close()
+
+            return RedirectResponse(url=f"/programmes/{programmeId}", status_code=303)
+        elif action == "log":
             cursor.execute(
                 'UPDATE "ProgrammeDay" SET "Completed" = TRUE, "Notes" = %s WHERE "ProgrammeDayID" = %s',
                 (notes or None, programmeDayId)
             )
 
-        conn.commit()
+            conn.commit()
+            cursor.close()
+            conn.close()
 
-        if action == "log":
-            return RedirectResponse(
-                url=f"/add-workout?programmeDayId={programmeDayId}&programmeId={programmeId}&activityName={quote(activityName or '')}",
-                status_code=303
-            )
-
-        return RedirectResponse(url=f"/programmes/{programmeId}", status_code=303)
-
+            return RedirectResponse(url=f"/add-workout?programmeDayId={programmeDayId}&programmeId={programmeId}&activityName={activityName}", status_code=303)
+    
     except Exception as e:
         print(f"Database error: {e}")
-        if conn:
-            conn.rollback()
-        return RedirectResponse(url=f"/programmes/{programmeId}?error=Failed+to+update", status_code=303)
+        conn.rollback()
+        cursor.close()
+        conn.close()
 
-    finally:
-        if cursor:
-            cursor.close()
-        if conn:
-            conn.close()
+    return RedirectResponse(url=f"/programmes/{programmeId}", status_code=303)

--- a/PyFitness/routers/programme.py
+++ b/PyFitness/routers/programme.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from database.db import get_connection
 from datetime import datetime
+from urllib.parse import quote
 
 router = APIRouter()
 
@@ -369,9 +370,8 @@ async def view_programme(request: Request, programmeId: int):
         notes_html = f'<p style="color:var(--text-secondary); font-size:0.85rem">{day[5]}</p>' if day[5] else ""
         workout_html = ''
         action_html = ''
-        if day[6]:
-            workout_html = f'<a href="/workouts/{day[6]}">View Workout</a>'
-        elif not day[4]:
+        
+        if not day[4]:
                action_html = f"""
                     <form action="/programmes/complete" method="post">
                         <input type="hidden" name="programmeDayId" value="{day[0]}">
@@ -491,38 +491,33 @@ async def complete_day(
     if "userId" not in request.session:
         return RedirectResponse(url="/login?error=Please+log+in", status_code=303)
 
+    action = (action or "").strip().lower()
+
     try:
         conn = get_connection()
         cursor = conn.cursor()
 
-        if action == "quick":
-            cursor.execute(
-                'UPDATE "ProgrammeDay" SET "Completed" = NOT "Completed", "Notes" = %s WHERE "ProgrammeDayID" = %s',
-                (notes or None, programmeDayId)
-            )
-            
+        cursor.execute(
+            'UPDATE "ProgrammeDay" SET "Completed" = TRUE, "Notes" = %s WHERE "ProgrammeDayID" = %s',
+            (notes or None, programmeDayId)
+        )
 
-            conn.commit()
-            cursor.close()
-            conn.close()
+        print("ROWS UPDATED:", cursor.rowcount)
 
-            return RedirectResponse(url=f"/programmes/{programmeId}", status_code=303)
-        elif action == "log":
-            cursor.execute(
-                'UPDATE "ProgrammeDay" SET "Completed" = TRUE, "Notes" = %s WHERE "ProgrammeDayID" = %s',
-                (notes or None, programmeDayId)
-            )
-
-            conn.commit()
-            cursor.close()
-            conn.close()
-
-            return RedirectResponse(url=f"/add-workout?programmeDayId={programmeDayId}&programmeId={programmeId}&activityName={activityName}", status_code=303)
-    
-    except Exception as e:
-        print(f"Database error: {e}")
-        conn.rollback()
+        conn.commit()
         cursor.close()
         conn.close()
+
+        if action == "log":
+            print("REDIRECTING TO:", f"/add-workout?programmeDayId={programmeDayId}&programmeId={programmeId}&activityName={activityName}")
+            return RedirectResponse(
+                url=f"/add-workout?programmeDayId={programmeDayId}&programmeId={programmeId}&activityName={quote(activityName or '')}",
+                status_code=303
+            )
+
+        return RedirectResponse(url=f"/programmes/{programmeId}", status_code=303)
+
+    except Exception as e:
+        print(f"Database error: {e}")
 
     return RedirectResponse(url=f"/programmes/{programmeId}", status_code=303)

--- a/PyFitness/routers/programme.py
+++ b/PyFitness/routers/programme.py
@@ -158,11 +158,11 @@ async def programmes(request: Request, error: str = None, success: str = None):
                             </div>
                             <div class="form-group">
                                 <label>Start Date</label>
-                                <input type="date" name="startDate" required>
+                                <input type="date" name="startDate" id="defaultStartDate" required onchange="document.getElementById('defaultEndDate').min = this.value">
                             </div>
                             <div class="form-group">
                                 <label>End Date</label>
-                                <input type="date" name="endDate" required>
+                                <input type="date" name="endDate" id="defaultEndDate" required>
                             </div>
                             <div class="form-group">
                                 <label>Target Event (optional)</label>
@@ -182,11 +182,11 @@ async def programmes(request: Request, error: str = None, success: str = None):
                             </div>
                             <div class="form-group">
                                 <label>Start Date</label>
-                                <input type="date" name="startDate" required>
+                                <input type="date" name="startDate" id="customStartDate" required onchange="document.getElementById('customEndDate').min = this.value">
                             </div>
                             <div class="form-group">
                                 <label>End Date</label>
-                                <input type="date" name="endDate" required>
+                                <input type="date" name="endDate" id="customEndDate" required>
                             </div>
                             <div class="form-group">
                                 <label>Target Event (optional)</label>
@@ -254,9 +254,8 @@ async def add_programme(
 
         if endDate < startDate:
             return RedirectResponse(url="/programmes?error=End+date+cannot+be+before+start+date", status_code=303)
-        
-    except Exception as e:
-        print(f"Error, {e}")
+
+    except ValueError:
         return RedirectResponse(url="/programmes?error=Invalid+date+format", status_code=303)
 
     if programmeType == "default":
@@ -426,13 +425,13 @@ async def view_programme(request: Request, programmeId: int):
                     <a href="/home" class="navbar-brand">FiTrackr</a>
                     <div class="navbar-links">
                         <a href="/home">Home</a>
-                        <a href="/add-workout">Add Workout</a>
                         <a href="/programmes" class="active">Programmes</a>
                         <a href="/competitions">Competitions</a>
                         <a href="/progress">Progress</a>
                         <a href="/guides">Help</a>
                         <a href="/settings">Settings</a>
-                        <a href="/logout" class="nav-btn">Logout</a>
+                        <a href="/add-workout" class="add-workout">Add Workout</a>
+                        <a href="/logout" class="logout">Logout</a>
                     </div>
                 </nav>
                 <div style="max-width:700px; margin: 40px auto; padding: 0 20px;">

--- a/PyFitness/routers/programme.py
+++ b/PyFitness/routers/programme.py
@@ -398,7 +398,7 @@ async def view_programme(request: Request, programmeId: int):
                 <form action="/programmes/complete" method="post">
                     <input type="hidden" name="programmeDayId" value="{day[0]}">
                     <input type="hidden" name="programmeId" value="{programmeId}">
-                    <button type="submit" name="action" value="quick" class="secondary">
+                    <button type="submit" name="action" value="undo" class="secondary">
                         Undo
                     </button>
                 </form>
@@ -497,19 +497,20 @@ async def complete_day(
         conn = get_connection()
         cursor = conn.cursor()
 
-        cursor.execute(
-            'UPDATE "ProgrammeDay" SET "Completed" = TRUE, "Notes" = %s WHERE "ProgrammeDayID" = %s',
-            (notes or None, programmeDayId)
-        )
-
-        print("ROWS UPDATED:", cursor.rowcount)
+        if action == "undo":
+            cursor.execute(
+                'UPDATE "ProgrammeDay" SET "Completed" = FALSE, "Notes" = NULL, "WorkoutID" = NULL WHERE "ProgrammeDayID" = %s',
+                (programmeDayId,)
+            )
+        else:
+            cursor.execute(
+                'UPDATE "ProgrammeDay" SET "Completed" = TRUE, "Notes" = %s WHERE "ProgrammeDayID" = %s',
+                (notes or None, programmeDayId)
+            )
 
         conn.commit()
-        cursor.close()
-        conn.close()
 
         if action == "log":
-            print("REDIRECTING TO:", f"/add-workout?programmeDayId={programmeDayId}&programmeId={programmeId}&activityName={activityName}")
             return RedirectResponse(
                 url=f"/add-workout?programmeDayId={programmeDayId}&programmeId={programmeId}&activityName={quote(activityName or '')}",
                 status_code=303
@@ -519,5 +520,12 @@ async def complete_day(
 
     except Exception as e:
         print(f"Database error: {e}")
+        if conn:
+            conn.rollback()
+        return RedirectResponse(url=f"/programmes/{programmeId}?error=Failed+to+update", status_code=303)
 
-    return RedirectResponse(url=f"/programmes/{programmeId}", status_code=303)
+    finally:
+        if cursor:
+            cursor.close()
+        if conn:
+            conn.close()


### PR DESCRIPTION
- Pace chart x-axis now date-based, same-day sessions averaged, 3-month scrollable window with prev/next buttons
- CardioType and CardioDate now saved to DB, exercise name falls back to cardio type if blank, min="0" on number inputs
- Date validation (end before start, start in past), HTML min attribute on end date input, navbar fixed on detail page
- Home calendar now shows programme days using generate_series, handles reversed start/end dates